### PR TITLE
Feature: Updated Record Type Query Method

### DIFF
--- a/force-app/main/default/classes/SObjectUtil.cls
+++ b/force-app/main/default/classes/SObjectUtil.cls
@@ -282,6 +282,7 @@ public with sharing class SObjectUtil {
         } else if (this.recordTypeIdMaster != null) {
             return this.recordTypeIdMaster;
         }
+        //  I don't really expect this to ever happen, just a catch-all
         return null;
     }
 

--- a/force-app/main/default/classes/SObjectUtil.cls
+++ b/force-app/main/default/classes/SObjectUtil.cls
@@ -40,6 +40,8 @@ public with sharing class SObjectUtil {
     public Map<String, Set<String>> evilObjectFieldNames = new Map<String, Set<String>>();
 
     private SObjectType theSObjectDescribe { get; private set; }
+    public Id recordTypeIdDefault { get; private set; }
+    public Id recordTypeIdMaster { get; private set; }
     public Set<String> setLookupDevNames { get; set; }
     public String selectAllString { get; private set; }                 //  A comma separated string of all fields on the SObject. Intended to act as * for SOQL queries
     public Set<String> fieldsRequired { get; private set; }             //  The DeveloperNames of required fields on the SObject level
@@ -58,7 +60,7 @@ public with sharing class SObjectUtil {
         //  Some standard SObjects don't like certain fields to be queried
         //  Will likely be added to over time. Is public in case fields are found
         //  with an object and they can be added to the filter here
-        evilObjectFieldNames.put('Contract', new Set<String>{
+        this.evilObjectFieldNames.put('Contract', new Set<String>{
             'ShippingStreet', 'ShippingCity', 'ShippingState', 'ShippingPostalCode', 'ShippingCountry', 'ShippingLatitude', 
             'ShippingLongitude', 'ShippingGeocodeAccuracy', 'ShippingAddress', 'Name'});
     
@@ -89,7 +91,7 @@ public with sharing class SObjectUtil {
         //  Populate data for the main SObject
         try {
             this.populateMapFieldInformation(reqSObjectType);
-            this.populateMapRecordTypes(reqSObjectType);
+            this.populateRecordTypeInformation(reqSObjectType);
         } catch (Exception e) {
             throw new SOBjectUtilException('Could not set up data for SObject: ' + reqSObjectType + '. An error occurred: ' + e.getMessage());
         }
@@ -187,30 +189,37 @@ public with sharing class SObjectUtil {
 
 
     /**
-     * Populates the public variable in the class: mapRecordTypeNameToId
-     * @param   String. API Name of the SObject to populate Record Type
-     *          information for.
+     * Uses the Schema class to get information about Record Types for the SObject. Also popultes
+     * Ids for the default record type Id for the user, and the master record type Id to fall back on
+     * @param   String. The name of the SObject
      */
-    private void populateMapRecordTypes(String theSObjectType) {
+    private void populateRecordTypeInformation(String theSObjectType) {
         this.mapRecordTypeNameToId = new Map<String, Id>();
+        Schema.DescribeSObjectResult sObjectResult = null;
 
-        for (RecordType rt : this.queryRecordTypes(theSObjectType)) {
-            this.mapRecordTypeNameToId.put(rt.DeveloperName, rt.Id);
+        try {
+            List<Schema.DescribeSObjectResult> tempSObjResults = Schema.describeSObjects(new List<String>{theSObjectType});
+            sObjectResult = tempSObjResults[0];
+        } catch (Exception e) {
+            System.debug('SObjectUtil: Could not populate record types using Schema for: ' + theSObjectType);
+            System.debug(e.getMessage());
+            return;
         }
-    }
 
-
-    /**
-     * Uses a SOQL query to get all record types for the given sobject
-     * @param   String. Name of the SObject to query record types for
-     * @return  List<RecordType>
-     */
-    private List<RecordType> queryRecordTypes(String theSObjectType) {
-        return [
-            SELECT Id, Name, DeveloperName, IsActive, SObjectType, Description
-            FROM RecordType
-            WHERE SObjectType = :theSObjectType
-        ];
+        for (Schema.RecordTypeInfo rti : sObjectResult.getRecordTypeInfos()) {
+            //  Default record type for the user running the code
+            if (rti.isDefaultRecordTypeMapping()) {
+                recordTypeIdDefault = rti.getRecordTypeId();
+            }
+            //  Default record type for the SObject. Used as a fall back
+            if (rti.isMaster()) {
+                recordTypeIdMaster = rti.getRecordTypeId();
+            }
+            //  Populate the map for DeveloperName to RecordTypeId
+            if (rti.getDeveloperName() != 'Master') {   //  Don't need as this isn't returned when using SOQL
+                mapRecordTypeNameToId.put(rti.getDeveloperName(), rti.getRecordTypeId());
+            }
+        }
     }
 
 
@@ -221,21 +230,24 @@ public with sharing class SObjectUtil {
     /**
      * Creates a query string for lookup fields on the current object
      * @param   String. The field related to the sobject lookup to create a query string for
+     *                  - If it is a standard lookup, then the field name will end with 'Id'
+     *                  - If it is a custom lookup, then the field name will end with '__c'
      * @return  String. The query string for the SObject
      */
-    public String createQueryStringForRelatedSObject(String passedFieldName) {
+    public String createQueryStringForRelatedSObject(String passedSObjFieldName) {
         //  Handle if the sobject lookup doesn't exist
-        if (!this.mapFieldNameToSObjectType.containsKey(passedFieldName)) {
+        if (!this.mapFieldNameToSObjectType.containsKey(passedSObjFieldName)) {
             return '';
         }
 
-        String sObjectName = this.mapFieldNameToSObjectType.get(passedFieldName);
+        String sObjectName = this.mapFieldNameToSObjectType.get(passedSObjFieldName);
         String queryString = '';
         for (String fieldName : this.mapRelatedSObjectFields.get(sObjectName)) {
-            queryString += sObjectName.replace('__c', '__r') + '.' + fieldName + ',';
+            queryString += passedSObjFieldName.replace('__c', '__r').removeEndIgnoreCase('id') + '.' + fieldName.capitalize() + ',';
         }
         return queryString.removeEnd(',');
     }
+
 
     /**
      * Same as above, but accepts Set<String>
@@ -247,6 +259,7 @@ public with sharing class SObjectUtil {
         }
         return queryString.removeEnd(',');
     }
+
 
     /**
      * Same as above, but accepts List<String>

--- a/force-app/main/default/classes/SObjectUtil.cls
+++ b/force-app/main/default/classes/SObjectUtil.cls
@@ -209,15 +209,15 @@ public with sharing class SObjectUtil {
         for (Schema.RecordTypeInfo rti : sObjectResult.getRecordTypeInfos()) {
             //  Default record type for the user running the code
             if (rti.isDefaultRecordTypeMapping()) {
-                recordTypeIdDefault = rti.getRecordTypeId();
+                this.recordTypeIdDefault = rti.getRecordTypeId();
             }
             //  Default record type for the SObject. Used as a fall back
             if (rti.isMaster()) {
-                recordTypeIdMaster = rti.getRecordTypeId();
+                this.recordTypeIdMaster = rti.getRecordTypeId();
             }
             //  Populate the map for DeveloperName to RecordTypeId
             if (rti.getDeveloperName() != 'Master') {   //  Don't need as this isn't returned when using SOQL
-                mapRecordTypeNameToId.put(rti.getDeveloperName(), rti.getRecordTypeId());
+                this.mapRecordTypeNameToId.put(rti.getDeveloperName(), rti.getRecordTypeId());
             }
         }
     }
@@ -268,6 +268,21 @@ public with sharing class SObjectUtil {
         Set<String> setSObjectNames = new Set<String>();
         setSObjectNames.addAll(sObjectNames);
         return this.createQueryStringForRelatedSObjects(setSObjectNames);
+    }
+
+
+    /**
+     * Returns the default record type Id for the user. If none is found,
+     * returns the Master record type Id. Returns null if both aren't populated
+     * @return  Id. The record type Id
+     */
+    public Id getDefaultRecordTypeId() {
+        if (this.recordTypeIdDefault != null) {
+            return this.recordTypeIdDefault;
+        } else if (this.recordTypeIdMaster != null) {
+            return this.recordTypeIdMaster;
+        }
+        return null;
     }
 
 

--- a/force-app/main/default/classes/SObjectUtilTest.cls
+++ b/force-app/main/default/classes/SObjectUtilTest.cls
@@ -357,6 +357,24 @@ private class SObjectUtilTest {
     }
 
 
+    /**
+     * Tests to make sure the correct record type Id fields are being populated
+     */
+    @isTest
+    static void testGetDefaultRecordTypeId() {
+        SObjectUtil accountUtil = new SObjectUtil('Account');
+        SObjectUtil contactUtil = new SObjectUtil('Contact');
+
+        System.assertNotEquals(null, accountUtil.getDefaultRecordTypeId());
+        System.assertNotEquals(null, accountUtil.recordTypeIdDefault);
+        System.assertNotEquals(null, accountUtil.recordTypeIdMaster);
+
+        System.assertNotEquals(null, contactUtil.getDefaultRecordTypeId());
+        System.assertNotEquals(null, contactUtil.recordTypeIdDefault);
+        System.assertNotEquals(null, contactUtil.recordTypeIdMaster);
+    }
+
+
     /*  ****************************************  */
     /*             Private Functions              */
     /*  ****************************************  */

--- a/force-app/main/default/classes/SObjectUtilTest.cls
+++ b/force-app/main/default/classes/SObjectUtilTest.cls
@@ -313,6 +313,28 @@ private class SObjectUtilTest {
         System.assertEquals(expectedRequiredFields, countedExistingFields);
     }
 
+
+    /**
+     * Tests the query string for lookup fields on a standard SObject
+     */
+    @isTest
+    static void testLookupQueryStringPopulate() {
+        //  Setup
+        SObjectUtil contractUtil = new SObjectUtil('Contract');
+        String sObjectNameFail = 'Account';
+        String sObjectNamePass = 'AccountId';
+
+        //  Test
+        String returnStringFail = contractUtil.createQueryStringForRelatedSObject(sObjectNameFail);
+        String returnStringPass = contractUtil.createQueryStringForRelatedSObject(sObjectnamePass);
+
+        //  Assert
+        System.assertEquals('', returnStringFail);
+        System.assert(returnStringPass.length() > 0);
+        System.assert(returnStringPass.contains(sObjectNamePass.removeEndIgnoreCase('Id')));
+    }
+
+
     /**
      * This is a hard one to successfully test as it depends on whether or not the object
      * in the org has any fields that are marked as unique


### PR DESCRIPTION
About
====
**SObjectUtil Dev**
Previously an SObject's record type was retrieved using a SOQL query.  This branch updates that to use the `Schema` object to populate the record types.  Using this method also allows us to find what the default record type is for the user, and reduces the number of SOQL queries made during setup by one.

New Var(s)
-----------
- Public Id: recordTypeIdDefault
The user's default record type Id for the SObject

- Public Id: recordTypeIdMaster
The master record type Id for the SObject

New Function(s)
------------------
- Private: populateRecordTypeInformation()
Populates record type information
- Public: testGetDefaultRecordTypeId()
Returns the default record type Id for the user for the object.  If none is found, use the master Id, otherwise return `null`

Unit Tests
-----------
- Added new unit test for testing the query string for a lookup sobject
- Added new unit test for testing if the correct data is returned when running `getDefaultRecordTypeId()`

Fixes
------
- Fixed an issue where when using `createQueryStringForRelatedSObject` for a standard lookup, the correct string would not be returned.